### PR TITLE
avoid 'out of date' warning in 1.12.1 client

### DIFF
--- a/SilverDragon.toc
+++ b/SilverDragon.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20200
+﻿## Interface: 11200
 ## Title: SilverDragon |cff7fff7f -Ace2-|r
 ## Notes: Remember where rares were updated by Miv
 ## Version: 1.0


### PR DESCRIPTION
avoid 'out of date' warning in 1.12.1 client